### PR TITLE
added one_time_password to enter_exchange

### DIFF
--- a/intralinks/__init__.py
+++ b/intralinks/__init__.py
@@ -228,13 +228,13 @@ class IntralinksClient:
 
         return intralinks.functions.v1.splashes.download_splash_image(self.api_client, exchange_id, path_without_extension)
     
-    def enter_exchange(self, exchange, accept_splash=None):
+    def enter_exchange(self, exchange, accept_splash=None, one_time_password=None):
         exchange_id = self._get_id(exchange)
 
         if self.api_client.is_v1() or self.use_v1:
-            return intralinks.functions.v1.splashes.enter_exchange(self.api_client, exchange_id, accept_splash=accept_splash)
+            return intralinks.functions.v1.splashes.enter_exchange(self.api_client, exchange_id, accept_splash=accept_splash, one_time_password=one_time_password)
         else:
-            return intralinks.functions.v2.splashes.enter_exchange(self.api_client, exchange_id, accept_splash=accept_splash)
+            return intralinks.functions.v2.splashes.enter_exchange(self.api_client, exchange_id, accept_splash=accept_splash, one_time_password=one_time_password)
     
     ###########################################################################################################
     # Folders

--- a/intralinks/functions/v1/splashes.py
+++ b/intralinks/functions/v1/splashes.py
@@ -17,13 +17,18 @@ def get_splash(api_client, exchange_id):
 
     return data
 
-def enter_exchange(api_client, exchange_id, accept_splash=None):
+def enter_exchange(api_client, exchange_id, accept_splash=None, one_time_password=False):
+    if one_time_password:
+        enter_content = {'xml':to_xml({'acceptSplash':accept_splash, 'oneTimePassword':one_time_password }, 'workspaceEntryRequest')}
+    else:
+        enter_content = {'xml':to_xml({'acceptSplash':accept_splash}, 'workspaceEntryRequest')}
+
     response = api_client.create(
         '/services/workspaces/entry', 
         params={
             'workspaceId':exchange_id
         }, 
-        data={'xml':to_xml({'acceptSplash':accept_splash}, 'workspaceEntryRequest')},
+        data=enter_content,
         api_version=1
     )
 

--- a/intralinks/functions/v2/splashes.py
+++ b/intralinks/functions/v2/splashes.py
@@ -17,10 +17,16 @@ def get_splash(api_client, exchange_id):
     
     return get_node_as_item(data, 'splash')
 
-def enter_exchange(api_client, exchange_id, accept_splash=False):
+def enter_exchange(api_client, exchange_id, accept_splash=False, one_time_password=False):
+
+    enter_content = {'acceptSplash': accept_splash}
+
+    if one_time_password:
+        enter_content['oneTimePassword'] = one_time_password
+
     response = api_client.create(
         '/v2/workspaces/{}/splash'.format(exchange_id), 
-        data=json.dumps({'acceptSplash': accept_splash}), 
+        data=json.dumps(enter_content), 
         headers={'Content-Type': 'application/json'},
         api_version=2
     )


### PR DESCRIPTION
Implemented the OTP (One Time Password) Token for exchanges that reply with 'ONE_TIME_PASSWORD'

When you enter an exchange and it replies with 'ONE_TIME_PASSWORD', it means the exchange has enhanced security.

The OTP token will be sent via email and/or sms.

Get that token, call the enter_exchange again, this time passing the token as the example. Sometimes the tokens can come with a leading '0', so make sure to pass it as string.

```
il.enter_exchange(exchange, accept_splash=True)
'ONE_TIME_PASSWORD'

il.enter_exchange(exchange, accept_splash=True, one_time_password='xxxxxxxx')
'ALLOW'
```

Tested on V2 API only. Have no V1 api_key to test.